### PR TITLE
Feat : 모달 추가, 컬러픽커 고침, result 갤러리 저장 API 연동

### DIFF
--- a/src/components/common/Fetcher/Fetcher.ts
+++ b/src/components/common/Fetcher/Fetcher.ts
@@ -1,7 +1,15 @@
 import * as Api from './Api';
 
 const port = 3000;
-const domain = `http://34.64.112.254:${port}/api`;
+const domain = `https://port-0-geulida-back-lhe2bli1h434z.sel4.cloudtype.app/api`;
+
+interface data {
+  color: string;
+  hexcode: string;
+  style: string;
+  summary: string;
+  url: string;
+}
 
 // 로그인
 async function userLogin(email: string, password: string) {
@@ -27,13 +35,7 @@ async function userCollection(page: number) {
 }
 
 // 결과 저장하기
-async function saveIntoCollection(color: string, style: string, summary: string, result: string) {
-  const data = {
-    color,
-    style,
-    summary,
-    result,
-  };
+async function saveIntoCollection(data: data) {
   return await Api.post(domain, 'collection', data);
 }
 

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -34,7 +34,7 @@ function Modal({ modalHandler, modalMessage, modalType, logoutHandler, navigateH
             로그아웃
           </button>
         )}
-        {modalType === 'choice' && (
+        {modalType === 'confirm' && (
           <button className={styles.confirmBtn} onClick={closeModal}>
             확인 후 닫기
           </button>

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -5,18 +5,19 @@ import { ReactComponent as Cancel } from 'assets/Cancel.svg';
 interface ModalProps {
   modalHandler: () => void;
   modalMessage: string;
-  modalType?: string;
+  modalType: string;
   logoutHandler?: () => void;
+  navigateHandler?: () => void;
 }
 
-function Modal({ modalHandler, modalMessage, modalType, logoutHandler }: ModalProps) {
+function Modal({ modalHandler, modalMessage, modalType, logoutHandler, navigateHandler }: ModalProps) {
   const closeModal = (e: React.MouseEvent) => {
     e.preventDefault();
     if (modalHandler) {
       modalHandler();
     }
   };
-
+  // navigate('/color-pick');
   return (
     <div className={styles.modalContainer}>
       <div className={styles.backdrop}></div>
@@ -28,13 +29,19 @@ function Modal({ modalHandler, modalMessage, modalType, logoutHandler }: ModalPr
           </div>
         </div>
         <div className={styles.modalMessage}>{modalMessage}</div>
-        {!modalType ? (
+        {modalType === 'logout' && (
           <button className={styles.confirmBtn} onClick={logoutHandler}>
             로그아웃
           </button>
-        ) : (
+        )}
+        {modalType === 'choice' && (
           <button className={styles.confirmBtn} onClick={closeModal}>
             확인 후 닫기
+          </button>
+        )}
+        {modalType === 'navigate' && (
+          <button className={styles.confirmBtn} onClick={navigateHandler}>
+            이동하기
           </button>
         )}
       </div>

--- a/src/components/common/Navi.tsx
+++ b/src/components/common/Navi.tsx
@@ -19,7 +19,7 @@ function Navi() {
 
   return (
     <>
-      {showModal && <Modal modalHandler={handleModalShow} modalMessage='로그아웃 하시겠습니까?' />}
+      {showModal && <Modal modalType='logout' modalHandler={handleModalShow} modalMessage='로그아웃 하시겠습니까?' />}
       <div className={styles.nav}>
         <nav>
           <div>

--- a/src/components/result/GallerySaveBtn/index.tsx
+++ b/src/components/result/GallerySaveBtn/index.tsx
@@ -58,7 +58,7 @@ function GallerySaveBtn({ storedData }: GallerySaveBtnProps) {
 
   return (
     <div>
-      {showModal && <Modal modalType='choice' modalHandler={handleModalShow} modalMessage='이미지가 갤러리에 저장되었습니다.' />}
+      {showModal && <Modal modalType='confirm' modalHandler={handleModalShow} modalMessage='이미지가 갤러리에 저장되었습니다.' />}
       <div className={styles.gallerySaveBtn}>
         <PhotoPlus onClick={handleSaveBtnClick} />
       </div>

--- a/src/components/result/GallerySaveBtn/index.tsx
+++ b/src/components/result/GallerySaveBtn/index.tsx
@@ -1,19 +1,25 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { saveIntoCollection } from '../../common/Fetcher/Fetcher';
 
 import { ReactComponent as PhotoPlus } from 'assets/PhotoPlus.svg';
 import styles from './gallerySaveBtn.module.scss';
 
-function GallerySaveBtn() {
-  // 실제 API 요청 데이터
-  // const getAnswerData = JSON.parse(sessionStorage.getItem('answerData') || '');
-  // const { color, style, summary, result } = getAnswerData;
+import Modal from 'components/common/Modal';
 
-  // API 요청 mock data
-  const getAnswerData = JSON.parse(sessionStorage.getItem('answerData') || '');
-  const { color, style } = getAnswerData;
-  const summary = 'summary';
-  const result = 'https://cdn.veritas-a.com/news/photo/old/2/admin_1198640645.jpg';
+interface data {
+  color: string;
+  hexcode: string;
+  style: string;
+  summary: string;
+  url: string;
+}
+
+interface GallerySaveBtnProps {
+  storedData: data;
+}
+
+function GallerySaveBtn({ storedData }: GallerySaveBtnProps) {
+  const [showModal, setShowModal] = useState<boolean>(false);
 
   // 임의로 토큰 쿠키에 욱여넣음
   // 토큰을 쿠키에 저장합니다.
@@ -30,6 +36,7 @@ function GallerySaveBtn() {
     }
     return null;
   }
+
   useEffect(() => {
     setToken(`${process.env.REACT_APP_TOKEN}`);
     console.log(getToken());
@@ -37,16 +44,21 @@ function GallerySaveBtn() {
 
   const handleSaveBtnClick = async () => {
     try {
-      const response = await saveIntoCollection(color, style, summary, result);
-      alert(response);
+      const response = await saveIntoCollection(storedData);
+      handleModalShow();
       console.log(response);
     } catch (err) {
       console.log('갤러리에 저장 실패: ', err);
     }
   };
 
+  function handleModalShow() {
+    setShowModal((prev) => !prev);
+  }
+
   return (
     <div>
+      {showModal && <Modal modalType='choice' modalHandler={handleModalShow} modalMessage='이미지가 갤러리에 저장되었습니다.' />}
       <div className={styles.gallerySaveBtn}>
         <PhotoPlus onClick={handleSaveBtnClick} />
       </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,13 +1,6 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement,
-);
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(<App />);

--- a/src/pages/ColorPickPage/colorPickPage.module.scss
+++ b/src/pages/ColorPickPage/colorPickPage.module.scss
@@ -75,6 +75,10 @@ $animation-duration: 1s;
   font-size: 40px;
   color: white;
   text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  span {
+    display: inline;
+    font-size: 40px;
+  }
 }
 
 .nextButton {

--- a/src/pages/ColorPickPage/index.tsx
+++ b/src/pages/ColorPickPage/index.tsx
@@ -58,7 +58,7 @@ function ColorPickPage() {
 
   return (
     <div className={styles.container}>
-      {showModal && <Modal modalType='choice' modalHandler={handleModalShow} modalMessage='원하는 컬러를 선택해주세요' />}
+      {showModal && <Modal modalType='confirm' modalHandler={handleModalShow} modalMessage='원하는 컬러를 선택해주세요' />}
       <div className={styles.left}></div>
       <div className={styles.colorPickerWrapper} ref={colorPickerRef}>
         {isShown && <ChromePicker className={styles.colorPicker} onChange={handleChangeColorPicker} color={colorPickerHex} />}

--- a/src/pages/ColorPickPage/index.tsx
+++ b/src/pages/ColorPickPage/index.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
+
+import { ChromePicker, ColorResult } from 'react-color';
 import { GetColorName } from 'hex-color-to-color-name';
 
 import Modal from 'components/common/Modal';
-import { ChromePicker, ColorResult, RGBColor } from 'react-color';
 
 import styles from './colorPickPage.module.scss';
 import { ReactComponent as RightArrow } from 'assets/RightArrow.svg';
@@ -12,25 +13,15 @@ function ColorPickPage() {
   const [isShown, setIsShown] = useState<boolean>(false);
   const [showModal, setShowModal] = useState<boolean>(false);
   const [colorPickerHex, setColorPickerHex] = useState<string>('');
-  const [namedColor, setNamedColor] = useState('');
-  const [colorPickerRGB, setColorPickerRGB] = useState({
-    r: 255,
-    g: 255,
-    b: 255,
-    a: 100,
-  });
+  const [namedColor, setNamedColor] = useState<string>('');
+
   const navigate = useNavigate();
   const colorPickerRef = useRef<HTMLDivElement>(null);
 
-  const { r, g, b, a } = colorPickerRGB;
-
   const handleChangeColorPicker = (color: ColorResult) => {
-    setColorPickerRGB({ ...colorPickerRGB, ...(color.rgb as RGBColor) });
     setColorPickerHex(color.hex);
-    const standardName = GetColorName(colorPickerHex);
+    const standardName = GetColorName(color.hex);
     setNamedColor(standardName);
-    console.log(colorPickerHex);
-    console.log(namedColor);
   };
 
   const handleClickOutside = (e: MouseEvent) => {
@@ -67,14 +58,14 @@ function ColorPickPage() {
 
   return (
     <div className={styles.container}>
-      {showModal && <Modal modalType='color' modalHandler={handleModalShow} modalMessage='원하는 컬러를 선택해주세요' />}
+      {showModal && <Modal modalType='choice' modalHandler={handleModalShow} modalMessage='원하는 컬러를 선택해주세요' />}
       <div className={styles.left}></div>
       <div className={styles.colorPickerWrapper} ref={colorPickerRef}>
         {isShown && <ChromePicker className={styles.colorPicker} onChange={handleChangeColorPicker} color={colorPickerHex} />}
         <div
           className={styles.colorPickerCircle}
           style={{
-            backgroundColor: `rgba(${r},${g},${b},${a})`,
+            backgroundColor: `${colorPickerHex}`,
           }}
           onClick={() => setIsShown((prev) => !prev)}
         >
@@ -82,7 +73,7 @@ function ColorPickPage() {
         </div>
 
         <div className={styles.question1}>
-          Q1. 원하는 <span style={{ color: colorPickerHex }}>컬러</span>를 선택해주세요
+          Q1. 원하는<span style={{ color: `${colorPickerHex}` }}>컬러</span>를 선택해주세요
         </div>
       </div>
 

--- a/src/pages/PainterPickPage/index.tsx
+++ b/src/pages/PainterPickPage/index.tsx
@@ -56,7 +56,7 @@ function PainterPickPage() {
 
   return (
     <div className={styles.container}>
-      {showModal && <Modal modalType='choice' modalHandler={handleModalShow} modalMessage='원하는 화풍을 선택해주세요' />}
+      {showModal && <Modal modalType='confirm' modalHandler={handleModalShow} modalMessage='원하는 화풍을 선택해주세요' />}
       <button className={styles.prevButton} onClick={() => navigate(-1)}>
         <LeftArrow className={styles.arrowLeft} />
       </button>

--- a/src/pages/PainterPickPage/index.tsx
+++ b/src/pages/PainterPickPage/index.tsx
@@ -56,7 +56,7 @@ function PainterPickPage() {
 
   return (
     <div className={styles.container}>
-      {showModal && <Modal modalType='color' modalHandler={handleModalShow} modalMessage='원하는 화풍을 선택해주세요' />}
+      {showModal && <Modal modalType='choice' modalHandler={handleModalShow} modalMessage='원하는 화풍을 선택해주세요' />}
       <button className={styles.prevButton} onClick={() => navigate(-1)}>
         <LeftArrow className={styles.arrowLeft} />
       </button>

--- a/src/pages/ResultPage/index.tsx
+++ b/src/pages/ResultPage/index.tsx
@@ -1,5 +1,8 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styles from './resultPage.module.scss';
 
+import Modal from 'components/common/Modal';
 import KakaoShareBtn from '../../components/result/KakaoShareBtn';
 import GallerySaveBtn from '../../components/result/GallerySaveBtn';
 import ImageSaveBtn from '../../components/result/ImageSaveBtn';
@@ -13,10 +16,57 @@ import ImageSaveBtn from '../../components/result/ImageSaveBtn';
  * 3. 갤러리 저장 버튼이 컴포넌트로 구현되어있으니, 여기서 api 부착하고 button 클릭 이벤트 props로 gellerysavebtn에 전달한다.
  *
  */
+// const storedData = sessionStorage.getItem('answerData');
+interface data {
+  color: string;
+  hexcode: string;
+  style: string;
+  summary: string;
+  url: string;
+}
 
 function ResultPage() {
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const [storedData, setStoredData] = useState<data>({
+    color: '',
+    hexcode: '',
+    style: '',
+    summary: '',
+    url: '',
+  });
+  const navigate = useNavigate();
+
+  const summary = 'summary';
+  const url = 'https://cdn.veritas-a.com/news/photo/old/2/admin_1198640645.jpg';
+
+  useEffect(() => {
+    try {
+      const getAnswerData = JSON.parse(sessionStorage.getItem('answerData') || '');
+      setStoredData({ ...storedData, color: getAnswerData.color, hexcode: getAnswerData.hexcode, style: getAnswerData.style, summary: summary, url: url });
+      console.log(getAnswerData);
+    } catch (err) {
+      console.error('Json에 유효한 값이 들어오지 않음');
+      handleModalShow();
+      console.log(showModal);
+    }
+  }, []);
+
+  function handleModalShow() {
+    setShowModal((prev) => !prev);
+  }
+
   return (
     <div className={styles.resultPage}>
+      {showModal && (
+        <Modal
+          modalType='navigate'
+          modalHandler={handleModalShow}
+          modalMessage='먼저 컬러와 화풍을 선택해주세요.'
+          navigateHandler={() => {
+            navigate('/color-pick');
+          }}
+        />
+      )}
       <div className={styles.resultPageContainer}>
         <section className={styles.resultContents}>
           <div className={styles.imageWrapper}>
@@ -26,7 +76,7 @@ function ResultPage() {
         </section>
         <section className={styles.resultBtnContainer}>
           <ImageSaveBtn />
-          <GallerySaveBtn />
+          <GallerySaveBtn storedData={storedData} />
           <KakaoShareBtn />
         </section>
       </div>


### PR DESCRIPTION
저 모달 코드 고쳤어요 모달 사용하시는 분들 참고해주세요.
modalType을 받아야겠어요.. 왜냐면 

세션에 데이터가 없는데도 불구하고
유저가 만약에 비정상적으로 url을 통해 result 페이지에 들어가려고 할 때의 로직을 추가했어요.
그럴 떄 모달을 띄우고, 이동하기 버튼을 눌러 navigate로 컬러 픽커부터 입력하게 만들고 싶었거든요..
(이 부분 혜지님도 구현하고 싶었던걸로 기억해요 ResultPage 코드 참고해주세요!)

사실 세션 데이터의 키값들 여부에 대한 validation로직을 짜서,
색상이 있는데, 화풍이 없다면 화풍부터, 색상이 없으면 색상부터, 채팅 내역이 없으면 채팅부터 
이동하게 만드려고 했는데 일단은 그 로직은 채팅내역까지 세션에 채워지면 다시 구현하도록 할게요.

아무튼 그러기 위해서는 모달 버튼에 따라 처리 방식이 달라지기에 modalType을 받아서 분기별로 나누려고요!
로그아웃은 modalType 제가 추가했습니다!
혜지님 모달 사용하는 부분 참고해서 수정 부탁드릴게요 ㅜㅅㅜ
