### PR TITLE
Feat: 이미지 url 요청 api 작성, cross-env 설치, CollectionItem 인터페이스 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react-color": "^3.0.6",
         "@types/react-dom": "^18.2.4",
         "axios": "^1.4.0",
+        "cross-env": "^7.0.3",
         "hex-color-to-color-name": "^1.0.2",
         "react": "^18.2.0",
         "react-color": "^2.19.3",
@@ -5837,6 +5838,23 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react-color": "^3.0.6",
     "@types/react-dom": "^18.2.4",
     "axios": "^1.4.0",
+    "cross-env": "^7.0.3",
     "hex-color-to-color-name": "^1.0.2",
     "react": "^18.2.0",
     "react-color": "^2.19.3",
@@ -24,7 +25,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "PORT=3001 react-scripts start",
+    "start": "cross-env PORT=3001 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/src/components/common/Fetcher/Fetcher.ts
+++ b/src/components/common/Fetcher/Fetcher.ts
@@ -40,7 +40,7 @@ async function saveIntoCollection(data: data) {
   return await Api.post(domain, 'collection', data);
 }
 
-// Chat 
+// Chat 생성하기
 async function generateChat(message: string) {
   const data = {
     message: message,
@@ -56,5 +56,14 @@ async function summaryChat(message: string) {
   return await Api.post(domain, 'chat/last', data, false);
 }
 
+// 이미지 생성하기
+async function makeImage(color: string, style: string, summary: string) {
+  const data = {
+    color: color, 
+    style: style, 
+    summary: summary,
+  };
+  return await Api.post(domain, 'img', data, false);
+}
 
-export { userLogin, userRegister, userCollection, saveIntoCollection, generateChat, summaryChat };
+export { userLogin, userRegister, userCollection, saveIntoCollection, generateChat, summaryChat, makeImage };

--- a/src/pages/Collection/CollectionItem.tsx
+++ b/src/pages/Collection/CollectionItem.tsx
@@ -6,6 +6,7 @@ interface CollectionItemProps {
   data: {
     _id: string;
     color: string;
+    hexcode: string;
     style: string;
     summary: string;
     url: string;


### PR DESCRIPTION
## 1. 이미지 api 요청과 세션 스토리지 저장 후 result 페이지 이동
이미지 요청도 너무 잘됩니당

![image](https://github.com/Geulida/Geulida-front/assets/71072214/7ada378c-777e-419a-baee-be88861cd344)


## 2. CollectionItem 인터페이스에 hexcode 프로퍼티 추가

- CollectionItem.tsx
```typescript
interface CollectionItemProps {
  data: {
    _id: string;
    color: string;
    hexcode: string;
    style: string;
    summary: string;
    url: string;
  };
}
```

## 3. Mac, Window port 변경 방식이 달라 cross-env 설치 및 스크립트 변경
**```npm i``` 한 번씩 부탁드려요!!**


- package.json
```json
  "scripts": {
    "start": "cross-env PORT=3001 react-scripts start",

    }
